### PR TITLE
fix: localise query replacements to url

### DIFF
--- a/403Bypasser.py
+++ b/403Bypasser.py
@@ -263,7 +263,7 @@ class BurpExtender(IBurpExtender, IScannerCheck, IContextMenuFactory, ITab):
 
 		originalRequest = self.helpers.bytesToString(request.getRequest())
 		for pathToTest in payloads:
-			headers[0] = firstline.replace(requestPath, pathToTest)
+			headers[0] = firstline.replace(requestPath, pathToTest, 1)
 			headersAsJavaSublist = ArrayList()
 			for header in headers:
 				headersAsJavaSublist.add(String(header))
@@ -282,7 +282,8 @@ class BurpExtender(IBurpExtender, IScannerCheck, IContextMenuFactory, ITab):
 
 			if newRequestStatusCode == "200":
 				originalRequestUrl = str(request.getUrl())
-				vulnerableReuqestUrl = originalRequestUrl.replace(requestPath,pathToTest)
+				scheme, urlWithoutScheme = originalRequestUrl.split("://")
+				vulnerableReuqestUrl = scheme + "://" + urlWithoutScheme.replace(requestPath, pathToTest, 1)
 
 				responseHeaders = str(self.helpers.analyzeResponse(newRequestResult.getResponse()).getHeaders()).split(",")
 				resultContentLength = "No CL in response"


### PR DESCRIPTION
Instead of mass replacing the URL path in the entire request, replace only the path in the first HTTP line. The fix here reuses the same pattern seen in other functions in this extension.

I've also isolated the makeHttpRequest call inside the try-block, to avoid conflating with possible exceptions in buildHttpRequest and other functions. In those other cases, we want exceptions to happen to see the error.